### PR TITLE
Fix import from module context

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   "jsnext:main": "dist.es2015/index.js",
   "sideEffects": false,
   "files": [
-    "dist/"
+    "dist/",
+    "dist.es2015/"
   ],
   "scripts": {
     "prettier": "prettier --write",


### PR DESCRIPTION
add es2015 build output to NPM package, so that module consumers can work with this package without error