### PR TITLE
Use ubuntu-latest for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
 jobs:
   test:
     name: Node.js ${{ matrix.node-version }}
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         node-version:


### PR DESCRIPTION
## Summary

Switch the GitHub Actions CI runner from `macos-latest` to `ubuntu-latest`.

## Notes

This keeps the Node.js CI workflow on a cheaper and more readily available hosted runner. The workflow does not appear to depend on macOS-specific behavior.

## Validation

Not run locally. GitHub Actions will validate the workflow on this branch.